### PR TITLE
Adding support for pre-trained dinov2 base and large models.

### DIFF
--- a/diffusion_policy/common/pylogging_util.py
+++ b/diffusion_policy/common/pylogging_util.py
@@ -1,0 +1,14 @@
+import logging
+import sys
+
+
+def setup_logging():
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setLevel(logging.INFO)
+    formatter = logging.Formatter(
+        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    )
+    handler.setFormatter(formatter)
+    root.addHandler(handler)

--- a/diffusion_policy/config/train_pusht_pretrained_dinov2_base.yaml
+++ b/diffusion_policy/config/train_pusht_pretrained_dinov2_base.yaml
@@ -2,7 +2,7 @@ defaults:
   - _self_
   - task: pusht_image
 
-name: pusht_resnet_pretrained_dinov2_base
+name: pusht_pretrained_dinov2_base
 _target_: diffusion_policy.workspace.train_diffusion_unet_image_workspace.TrainDiffusionUnetImageWorkspace
 
 task_name: ${task.name}

--- a/diffusion_policy/config/train_pusht_pretrained_dinov2_base.yaml
+++ b/diffusion_policy/config/train_pusht_pretrained_dinov2_base.yaml
@@ -1,0 +1,148 @@
+defaults:
+  - _self_
+  - task: pusht_image
+
+name: pusht_resnet_pretrained_dinov2_base
+_target_: diffusion_policy.workspace.train_diffusion_unet_image_workspace.TrainDiffusionUnetImageWorkspace
+
+task_name: ${task.name}
+shape_meta: ${task.shape_meta}
+exp_name: "default"
+
+horizon: 16
+n_obs_steps: 2
+n_action_steps: 8
+n_latency_steps: 0
+dataset_obs_steps: ${n_obs_steps}
+past_action_visible: False
+keypoint_visible_rate: 1.0
+obs_as_global_cond: True
+
+policy:
+  _target_: diffusion_policy.policy.diffusion_unet_image_policy.DiffusionUnetImagePolicy
+  shape_meta: ${shape_meta}
+  noise_scheduler:
+    _target_: diffusers.schedulers.scheduling_ddim.DDIMScheduler
+    num_train_timesteps: 100
+    beta_start: 0.0001
+    beta_end: 0.02
+    # beta_schedule is important
+    # this is the best we found
+    beta_schedule: squaredcos_cap_v2
+    clip_sample: True
+    set_alpha_to_one: True
+    steps_offset: 0
+    prediction_type: epsilon # or sample
+
+  obs_encoder:
+    _target_: diffusion_policy.model.vision.multi_image_obs_encoder.MultiImageObsEncoder
+    shape_meta: ${shape_meta}
+    rgb_model:
+      _target_: diffusion_policy.model.vision.model_getter.get_dinov2
+      name: facebook/dinov2-base
+    crop_shape: null
+    random_crop: False
+    use_group_norm: False
+    share_rgb_model: True
+    imagenet_norm: False
+
+  horizon: ${horizon}
+  n_action_steps: ${eval:'${n_action_steps}+${n_latency_steps}'}
+  n_obs_steps: ${n_obs_steps}
+  num_inference_steps: 100
+  obs_as_global_cond: ${obs_as_global_cond}
+  # crop_shape: null
+  diffusion_step_embed_dim: 128
+  down_dims: [512, 1024, 2048]
+  kernel_size: 5
+  n_groups: 8
+  cond_predict_scale: True
+
+  # scheduler.step params
+  # predict_epsilon: True
+
+ema:
+  _target_: diffusion_policy.model.diffusion.ema_model.EMAModel
+  update_after_step: 0
+  inv_gamma: 1.0
+  power: 0.75
+  min_value: 0.0
+  max_value: 0.9999
+
+dataloader:
+  batch_size: 64
+  num_workers: 8
+  shuffle: True
+  pin_memory: True
+  persistent_workers: True
+
+val_dataloader:
+  batch_size: 64
+  num_workers: 8
+  shuffle: False
+  pin_memory: True
+  persistent_workers: True
+
+optimizer:
+  _target_: torch.optim.AdamW
+  lr: 1.0e-4
+  betas: [0.95, 0.999]
+  eps: 1.0e-8
+  weight_decay: 1.0e-6
+
+training:
+  device: "cuda:0"
+  seed: 42
+  debug: False
+  resume: True
+  # optimization
+  lr_scheduler: cosine
+  lr_warmup_steps: 500
+  num_epochs: 3000
+  gradient_accumulate_every: 1
+  # EMA destroys performance when used with BatchNorm
+  # replace BatchNorm with GroupNorm.
+  use_ema: True
+  freeze_encoder: True
+  # training loop control
+  # in epochs
+  rollout_every: 50
+  checkpoint_every: 50
+  val_every: 1
+  sample_every: 5
+  # steps per epoch
+  max_train_steps: null
+  max_val_steps: null
+  # misc
+  tqdm_interval_sec: 1.0
+
+logging:
+  project: diffusion_policy_debug
+  resume: True
+  mode: online
+  name: ${now:%Y.%m.%d-%H.%M.%S}_${name}_${task_name}
+  tags: ["${name}", "${task_name}", "${exp_name}"]
+  id: null
+  group: null
+
+checkpoint:
+  topk:
+    monitor_key: train_loss
+    mode: min
+    k: 5
+    format_str: 'epoch={epoch:04d}-train_loss={train_loss:.3f}.ckpt'
+  save_last_ckpt: True
+  save_last_snapshot: False
+
+multi_run:
+  run_dir: data/outputs/${now:%Y.%m.%d}/${now:%H.%M.%S}_${name}_${task_name}
+  wandb_name_base: ${now:%Y.%m.%d-%H.%M.%S}_${name}_${task_name}
+
+hydra:
+  job:
+    override_dirname: ${name}
+  run:
+    dir: data/outputs/${now:%Y.%m.%d}/${now:%H.%M.%S}_${name}_${task_name}
+  sweep:
+    dir: data/outputs/${now:%Y.%m.%d}/${now:%H.%M.%S}_${name}_${task_name}
+    subdir: ${hydra.job.num}

--- a/diffusion_policy/config/train_pusht_pretrained_dinov2_large.yaml
+++ b/diffusion_policy/config/train_pusht_pretrained_dinov2_large.yaml
@@ -2,7 +2,7 @@ defaults:
   - _self_
   - task: pusht_image
 
-name: pusht_resnet_pretrained_dinov2_base
+name: pusht_pretrained_dinov2_large
 _target_: diffusion_policy.workspace.train_diffusion_unet_image_workspace.TrainDiffusionUnetImageWorkspace
 
 task_name: ${task.name}

--- a/diffusion_policy/config/train_pusht_pretrained_dinov2_large.yaml
+++ b/diffusion_policy/config/train_pusht_pretrained_dinov2_large.yaml
@@ -1,0 +1,148 @@
+defaults:
+  - _self_
+  - task: pusht_image
+
+name: pusht_resnet_pretrained_dinov2_base
+_target_: diffusion_policy.workspace.train_diffusion_unet_image_workspace.TrainDiffusionUnetImageWorkspace
+
+task_name: ${task.name}
+shape_meta: ${task.shape_meta}
+exp_name: "default"
+
+horizon: 16
+n_obs_steps: 2
+n_action_steps: 8
+n_latency_steps: 0
+dataset_obs_steps: ${n_obs_steps}
+past_action_visible: False
+keypoint_visible_rate: 1.0
+obs_as_global_cond: True
+
+policy:
+  _target_: diffusion_policy.policy.diffusion_unet_image_policy.DiffusionUnetImagePolicy
+  shape_meta: ${shape_meta}
+  noise_scheduler:
+    _target_: diffusers.schedulers.scheduling_ddim.DDIMScheduler
+    num_train_timesteps: 100
+    beta_start: 0.0001
+    beta_end: 0.02
+    # beta_schedule is important
+    # this is the best we found
+    beta_schedule: squaredcos_cap_v2
+    clip_sample: True
+    set_alpha_to_one: True
+    steps_offset: 0
+    prediction_type: epsilon # or sample
+
+  obs_encoder:
+    _target_: diffusion_policy.model.vision.multi_image_obs_encoder.MultiImageObsEncoder
+    shape_meta: ${shape_meta}
+    rgb_model:
+      _target_: diffusion_policy.model.vision.model_getter.get_dinov2
+      name: facebook/dinov2-large
+    crop_shape: null
+    random_crop: False
+    use_group_norm: False
+    share_rgb_model: True
+    imagenet_norm: False
+
+  horizon: ${horizon}
+  n_action_steps: ${eval:'${n_action_steps}+${n_latency_steps}'}
+  n_obs_steps: ${n_obs_steps}
+  num_inference_steps: 100
+  obs_as_global_cond: ${obs_as_global_cond}
+  # crop_shape: null
+  diffusion_step_embed_dim: 128
+  down_dims: [512, 1024, 2048]
+  kernel_size: 5
+  n_groups: 8
+  cond_predict_scale: True
+
+  # scheduler.step params
+  # predict_epsilon: True
+
+ema:
+  _target_: diffusion_policy.model.diffusion.ema_model.EMAModel
+  update_after_step: 0
+  inv_gamma: 1.0
+  power: 0.75
+  min_value: 0.0
+  max_value: 0.9999
+
+dataloader:
+  batch_size: 64
+  num_workers: 8
+  shuffle: True
+  pin_memory: True
+  persistent_workers: True
+
+val_dataloader:
+  batch_size: 64
+  num_workers: 8
+  shuffle: False
+  pin_memory: True
+  persistent_workers: True
+
+optimizer:
+  _target_: torch.optim.AdamW
+  lr: 1.0e-4
+  betas: [0.95, 0.999]
+  eps: 1.0e-8
+  weight_decay: 1.0e-6
+
+training:
+  device: "cuda:0"
+  seed: 42
+  debug: False
+  resume: True
+  # optimization
+  lr_scheduler: cosine
+  lr_warmup_steps: 500
+  num_epochs: 3000
+  gradient_accumulate_every: 1
+  # EMA destroys performance when used with BatchNorm
+  # replace BatchNorm with GroupNorm.
+  use_ema: True
+  freeze_encoder: True
+  # training loop control
+  # in epochs
+  rollout_every: 50
+  checkpoint_every: 50
+  val_every: 1
+  sample_every: 5
+  # steps per epoch
+  max_train_steps: null
+  max_val_steps: null
+  # misc
+  tqdm_interval_sec: 1.0
+
+logging:
+  project: diffusion_policy_debug
+  resume: True
+  mode: online
+  name: ${now:%Y.%m.%d-%H.%M.%S}_${name}_${task_name}
+  tags: ["${name}", "${task_name}", "${exp_name}"]
+  id: null
+  group: null
+
+checkpoint:
+  topk:
+    monitor_key: train_loss
+    mode: min
+    k: 5
+    format_str: 'epoch={epoch:04d}-train_loss={train_loss:.3f}.ckpt'
+  save_last_ckpt: True
+  save_last_snapshot: False
+
+multi_run:
+  run_dir: data/outputs/${now:%Y.%m.%d}/${now:%H.%M.%S}_${name}_${task_name}
+  wandb_name_base: ${now:%Y.%m.%d-%H.%M.%S}_${name}_${task_name}
+
+hydra:
+  job:
+    override_dirname: ${name}
+  run:
+    dir: data/outputs/${now:%Y.%m.%d}/${now:%H.%M.%S}_${name}_${task_name}
+  sweep:
+    dir: data/outputs/${now:%Y.%m.%d}/${now:%H.%M.%S}_${name}_${task_name}
+    subdir: ${hydra.job.num}

--- a/diffusion_policy/dataset/pusht_image_dataset_augment.py
+++ b/diffusion_policy/dataset/pusht_image_dataset_augment.py
@@ -1,0 +1,67 @@
+import logging
+import os
+import time
+
+import numpy as np
+import torch
+import zarr
+from transformers import AutoImageProcessor, AutoModel
+
+from diffusion_policy.common.pylogging_util import setup_logging
+
+
+def add_embeddings(
+    hf_model_name="facebook/dinov2-base", store_key="dinov2_base", step=200
+):
+    torch.manual_seed(42)
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    dist_group = zarr.open(
+        os.path.expanduser("./data/pusht/pusht_cchi_v7_replay.zarr"), "a"
+    )
+
+    processor = AutoImageProcessor.from_pretrained(hf_model_name)
+    model = AutoModel.from_pretrained(hf_model_name)
+    model.to(device)
+
+    start_time = time.perf_counter()
+    for _, group in dist_group.items():
+        for k1, v1 in group.items():
+            if k1 == "img":
+                embeddings = []
+                for i in range(0, v1.shape[0], step):
+                    frame = torch.from_numpy(v1[i:i+step])
+                    frame = (frame * 255).type(torch.uint8)
+                    inputs = processor(images=frame, return_tensors="pt")
+                    inputs.to(device)
+                    with torch.no_grad():
+                        outputs = model(**inputs)
+                        last_hidden_states = outputs[0]
+                        logging.info(
+                            f"frame_idx: {i} - {list(last_hidden_states.cpu().mean(dim=1).shape)}"
+                        )
+                        embeddings.append(last_hidden_states.cpu().mean(dim=1))
+    embeddings_np = np.concatenate(embeddings, axis=0)
+    dist_group[f"/data/{store_key}"] = embeddings_np
+    end_time = time.perf_counter()
+    logging.info(
+        f"processed {hf_model_name} embeddings for {embeddings_np.shape[0]} frames in {end_time - start_time} seconds, stored {embeddings_np.shape} in data store under key: /data/{store_key}"
+    )
+
+
+def test():
+    dist_group = zarr.open(
+        os.path.expanduser("./data/pusht/pusht_cchi_v7_replay.zarr"), "r"
+    )
+    
+    for key1, val1 in dist_group.items():
+        for key2, val2 in val1.items():
+            logging.info(f"{key1} - {key2} - {val2.shape}")
+
+
+if __name__ == "__main__":
+    setup_logging()
+    add_embeddings(hf_model_name="facebook/dinov2-large", store_key="dinov2_large")
+    add_embeddings(hf_model_name="facebook/dinov2-base", store_key="dinov2_base")
+    # add_embeddings(hf_model_name="facebook/vc1-large", store_key="vc1_large")
+    test()

--- a/diffusion_policy/model/vision/model_getter.py
+++ b/diffusion_policy/model/vision/model_getter.py
@@ -1,6 +1,7 @@
 import torch
 import torchvision
 
+
 def get_resnet(name, weights=None, **kwargs):
     """
     name: resnet18, resnet34, resnet50
@@ -26,3 +27,8 @@ def get_r3m(name, **kwargs):
     resnet_model = r3m_model.convnet
     resnet_model = resnet_model.to('cpu')
     return resnet_model
+
+def get_dinov2(name, **kwargs):
+    from transformers import AutoModel
+    model = AutoModel.from_pretrained(name)
+    return model.to('cpu')


### PR DESCRIPTION
## CONTEXT
- Adding support for pre-trained dinov2 base and large models

## TESTING

### DINOV2 BASE
```
python train.py --config-dir=./diffusion_policy/config  --config-name=train_pusht_pretrained_dinov2_base.yaml training.seed=42 training.device=cuda:0 hydra.run.dir='data/outputs/${now:%Y.%m.%d}/${now:%H.%M.%S}_${name}_${task_name}'
```

### DINOV2 LARGE
```
python train.py --config-dir=./diffusion_policy/config  --config-name=train_pusht_pretrained_dinov2_large.yaml training.seed=42 training.device=cuda:0 hydra.run.dir='data/outputs/${now:%Y.%m.%d}/${now:%H.%M.%S}_${name}_${task_name}'
```